### PR TITLE
Add Places Serializer Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ class MyLocationModelSerializer(serializers.Serializer):
     location = PlaceSerializerField()
 ```
 
+How the location data is displayed when doing a GET request in JSON with a serializer that has the field included, and is also how the data should be provided when doing a PUT/PATCH/POST:
+
+```json
+"location": {
+    "city": "Stockholm",
+    "country": "Sverige",
+    "latitude": "59.32932349999999",
+    "longitude": "18.0685808"
+}
+```
+
 ## Demo
 ------
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A Django app for store places with autocomplete function and a related map to th
 
 Install `dj-places` and add it to your installed apps:
 
-```
+```bash
 $ pip install dj-places
 ```
 
-```
+```py
     INSTALLED_APPS = (
     	...
     	'places',
@@ -21,9 +21,20 @@ $ pip install dj-places
     )
 ```
 
+Add djangorestframework to your installed apps (required for the package as it provide a serializer field):
+
+```py
+    INSTALLED_APPS = (
+    	...
+    	'rest_framework',
+    	...
+    )
+```
+
+
 Add the following settings and maps api key ([read more here](https://developers.google.com/maps/documentation/javascript/reference/map)):
 
-```python
+```bash
 PLACES_MAPS_API_KEY='YourAwesomeUltraSecretKey'
 PLACES_MAP_WIDGET_HEIGHT=480
 PLACES_MAP_OPTIONS='{"center": { "lat": 38.971584, "lng": -95.235072 }, "zoom": 10}'
@@ -35,7 +46,7 @@ PLACES_MARKER_OPTIONS='{"draggable": true}'
 
 Then use it in a project:
 
-```python
+```py
 from django.db import models
 from places.fields import PlacesField
 
@@ -47,16 +58,16 @@ class MyLocationModel(models.Model):
 
 This enables the following API:
 
-```python
-    >>> from myapp.models import ModelName
-    >>> poi = ModelName.objects.get(id=1)
-    >>> poi.position
+```bash
+    >>> from myapp.models import MyLocationModel
+    >>> poi = MyLocationModel.objects.get(id=1)
+    >>> poi.location
     Place('Metrocentro, Managua, Nicaragua', 52.522906, 13.41156)
-    >>> poi.position.place
+    >>> poi.location.place
     'Metrocentro, Managua, Nicaragua'
-    >>> poi.position.latitude
+    >>> poi.location.latitude
     52.522906
-    >>> poi.position.longitude
+    >>> poi.location.longitude
     13.41156
 ```
 
@@ -72,6 +83,17 @@ For using outside the Django Admin:
 ```
 Remember to add the `{{ form.media }}` in your template.
 
+
+For usage in Djangorestframework Serializers:
+
+```py
+from places.serializers import PlacesSerializerField
+from rest_framework import serializers
+
+class MyLocationModelSerializer(serializers.Serializer):
+    location = PlaceSerializerField()
+```
+
 ## Demo
 ------
 
@@ -85,6 +107,9 @@ Tools used in rendering this package:
 *  [Cookiecutter](https://github.com/audreyr/cookiecutter)
 *  [cookiecutter-djangopackage](https://github.com/pydanny/cookiecutter-djangopackage)
 *  [jquery-geocomplete](https://github.com/ubilabs/geocomplete) (_no longer used in the project._)
+
+Contributors
+[minifisk](https://github.com/minifisk) - Adding serializer field
 
 ### Similar Projects
 ------------

--- a/places/__init__.py
+++ b/places/__init__.py
@@ -8,7 +8,7 @@ __version__ = '5.2.1'
 
 
 class Places(object):
-    def __init__(self, place, latitude, longitude):
+    def __init__(self, place, latitude, longitude, name=None):
 
         if isinstance(latitude, float) or isinstance(latitude, int):
             latitude = str(latitude)
@@ -16,11 +16,12 @@ class Places(object):
             longitude = str(longitude)
 
         self.place = place
+        self.name = name 
         self.latitude = Decimal(latitude)
         self.longitude = Decimal(longitude)
 
     def __str__(self):
-        return "%s, %s, %s" % (self.place, self.latitude, self.longitude)
+        return "%s, %s, %s, %s" % (self.place, self.latitude, self.longitude, self.name)
 
     def __repr__(self):
         return "Places(%s)" % str(self)

--- a/places/__init__.py
+++ b/places/__init__.py
@@ -8,7 +8,7 @@ __version__ = '5.2.1'
 
 
 class Places(object):
-    def __init__(self, place, latitude, longitude, name=None):
+    def __init__(self, place, latitude, longitude, name=None, formatted_address=None):
 
         if isinstance(latitude, float) or isinstance(latitude, int):
             latitude = str(latitude)
@@ -17,11 +17,12 @@ class Places(object):
 
         self.place = place
         self.name = name 
+        self.formatted_address = formatted_address
         self.latitude = Decimal(latitude)
         self.longitude = Decimal(longitude)
 
     def __str__(self):
-        return "%s, %s, %s, %s" % (self.place, self.latitude, self.longitude, self.name)
+        return "%s, %s, %s, %s, %s" % (self.place, self.latitude, self.longitude, self.name, self.formatted_address)
 
     def __repr__(self):
         return "Places(%s)" % str(self)

--- a/places/fields.py
+++ b/places/fields.py
@@ -31,27 +31,24 @@ class PlacesField(models.Field):
         if isinstance(value, Places):
             return value
 
-        if isinstance(value, list):
-            return Places(value[0], value[1], value[2])
+        # Split the value into parts and strip spaces
+        value_parts = [val.strip() for val in value.split(',')]
 
-        value_parts = [Decimal(val) for val in value.split(',')[-2:]]
-
+        # Extract latitude and longitude
         try:
-            latitude = value_parts[0]
-        except IndexError:
-            latitude = '0.0'
+            latitude = Decimal(value_parts[-3])
+            longitude = Decimal(value_parts[-2])
+        except (IndexError, ValueError, decimal.InvalidOperation):
+            # Default values in case of error
+            latitude = Decimal('0.0')
+            longitude = Decimal('0.0')
 
-        try:
-            longitude = value_parts[1]
-        except IndexError:
-            longitude = '0.0'
+        # Extract place and name
+        place = ','.join(value_parts[:-3]) if len(value_parts) > 3 else None
+        name = value_parts[-1] if len(value_parts) > 3 else None
 
-        try:
-            place = ','.join(value.split(',')[:-2])
-        except:
-            pass
+        return Places(place, latitude, longitude, name)
 
-        return Places(place, latitude, longitude)
 
     def from_db_value(self, value, expression, connection):
         return self.to_python(value)

--- a/places/fields.py
+++ b/places/fields.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from decimal import Decimal
+import decimal
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _

--- a/places/fields.py
+++ b/places/fields.py
@@ -26,8 +26,13 @@ class PlacesField(JSONField):
         super(PlacesField, self).__init__(*args, **kwargs)
 
     def to_python(self, value):
+        print('value from to_python', value)
         if isinstance(value, Places):
             return value
+        
+        if isinstance(value, list):
+            if len(value) == 3:
+                print('value', value)
 
         if value is None or isinstance(value, dict):
             return value

--- a/places/forms.py
+++ b/places/forms.py
@@ -11,6 +11,10 @@ class PlacesField(forms.MultiValueField):
     default_error_messages = {'invalid': _('Enter a valid geoposition.')}
 
     def __init__(self, *args, **kwargs):
+
+        kwargs.pop('encoder', None)
+        kwargs.pop('decoder', None)
+
         fields = (
             forms.CharField(label=_('place')),
             forms.DecimalField(label=_('Latitude')),

--- a/places/forms.py
+++ b/places/forms.py
@@ -11,8 +11,6 @@ class PlacesField(forms.MultiValueField):
     default_error_messages = {'invalid': _('Enter a valid geoposition.')}
 
     def __init__(self, *args, **kwargs):
-        print("Initializing PlacesField with args:", args, "kwargs:", kwargs)
-
         kwargs.pop('encoder', None)
         kwargs.pop('decoder', None)
 
@@ -37,13 +35,24 @@ class PlacesField(forms.MultiValueField):
         return {'class': ' '.join(classes)}
 
     def compress(self, value_list):
-        print("Compressing values in PlacesField:", value_list)
         if value_list:
-            return value_list
+            place = Places(
+                latitude=value_list[1],
+                longitude=value_list[2],
+                name=value_list[3],
+                formatted_address=value_list[4],
+                country=value_list[5],
+                city=value_list[6],
+                state=value_list[7],
+            )
+            return place
         return ""
+
+
+    def clean(self, value):
+        return value
     
     def prepare_value(self, value):
-        print("Preparing value in PlacesField:", value)
         if isinstance(value, Places):
             return value.to_dict()
         return value

--- a/places/forms.py
+++ b/places/forms.py
@@ -11,6 +11,7 @@ class PlacesField(forms.MultiValueField):
     default_error_messages = {'invalid': _('Enter a valid geoposition.')}
 
     def __init__(self, *args, **kwargs):
+        print("Initializing PlacesField with args:", args, "kwargs:", kwargs)
 
         kwargs.pop('encoder', None)
         kwargs.pop('decoder', None)
@@ -19,6 +20,11 @@ class PlacesField(forms.MultiValueField):
             forms.CharField(label=_('place')),
             forms.DecimalField(label=_('Latitude')),
             forms.DecimalField(label=_('Longitude')),
+            forms.CharField(label=_('Name'), required=False),
+            forms.CharField(label=_('Formatted Address'), required=False),
+            forms.CharField(label=_('Country'), required=False),
+            forms.CharField(label=_('City'), required=False),
+            forms.CharField(label=_('State'), required=False),
         )
         if 'initial' in kwargs and kwargs['initial'] != '':
             kwargs['initial'] = Places(*kwargs['initial'].split(','))
@@ -31,6 +37,15 @@ class PlacesField(forms.MultiValueField):
         return {'class': ' '.join(classes)}
 
     def compress(self, value_list):
+        print("Compressing values in PlacesField:", value_list)
         if value_list:
             return value_list
         return ""
+    
+    def prepare_value(self, value):
+        print("Preparing value in PlacesField:", value)
+        if isinstance(value, Places):
+            return value.to_dict()
+        return value
+    
+

--- a/places/serializers.py
+++ b/places/serializers.py
@@ -19,7 +19,7 @@ class PlacesSerializerField(serializers.Field):
         if not value.place:
             return None
 
-        place_parts = value.place.split(', ')
+        place_parts = value.place.split(',')
         country = place_parts[1] if len(place_parts) > 1 else place_parts[0]
         city = place_parts[0] if len(place_parts) > 1 else ''
 
@@ -63,4 +63,5 @@ class PlacesSerializerField(serializers.Field):
         formatted_address = data.get('formatted_address')
 
         place = f"{country}, {city}" 
+
         return Places(place, latitude, longitude, name, formatted_address)

--- a/places/serializers.py
+++ b/places/serializers.py
@@ -19,8 +19,8 @@ class PlacesSerializerField(serializers.Field):
             return None
 
         place_parts = value.place.split(', ')
-        country = place_parts[0] if len(place_parts) > 1 else ''
-        city = place_parts[1] if len(place_parts) > 1 else place_parts[0]
+        country = place_parts[1] if len(place_parts) > 1 else place_parts[0]
+        city = place_parts[0] if len(place_parts) > 1 else ''
 
         return {
             'country': country,

--- a/places/serializers.py
+++ b/places/serializers.py
@@ -1,7 +1,5 @@
-from decimal import Decimal, InvalidOperation
-
 from rest_framework import serializers
-
+from decimal import Decimal, InvalidOperation
 from . import Places
 
 class PlacesSerializerField(serializers.Field):
@@ -26,7 +24,8 @@ class PlacesSerializerField(serializers.Field):
             'country': country,
             'city': city,
             'latitude': str(value.latitude),
-            'longitude': str(value.longitude)
+            'longitude': str(value.longitude),
+            'name': value.name
         }
 
     def to_internal_value(self, data):
@@ -55,6 +54,8 @@ class PlacesSerializerField(serializers.Field):
             longitude = Decimal(longitude)
         except (ValueError, TypeError, InvalidOperation):
             raise serializers.ValidationError({"longitude": "Longitude must be a valid number"})
+        
+        name = data.get('name')
 
         place = f"{country}, {city}" 
-        return Places(place, latitude, longitude)
+        return Places(place, latitude, longitude, name)

--- a/places/serializers.py
+++ b/places/serializers.py
@@ -25,7 +25,8 @@ class PlacesSerializerField(serializers.Field):
             'city': city,
             'latitude': str(value.latitude),
             'longitude': str(value.longitude),
-            'name': value.name
+            'name': value.name,
+            'formatted_address': value.formatted_address,
         }
 
     def to_internal_value(self, data):
@@ -56,6 +57,7 @@ class PlacesSerializerField(serializers.Field):
             raise serializers.ValidationError({"longitude": "Longitude must be a valid number"})
         
         name = data.get('name')
+        formatted_address = data.get('formatted_address')
 
         place = f"{country}, {city}" 
-        return Places(place, latitude, longitude, name)
+        return Places(place, latitude, longitude, name, formatted_address)

--- a/places/serializers.py
+++ b/places/serializers.py
@@ -9,59 +9,9 @@ class PlacesSerializerField(serializers.Field):
     For serialization, it converts the Places object to this dictionary format.
     """
 
-    def to_representation(self, value):
-        """
-        Converts the Places object to a dictionary for serialization.
-        """
-        if not value or not isinstance(value, Places):
-            return None
-
-        if not value.place:
-            return None
-
-        place_parts = value.place.split(',')
-        country = place_parts[1] if len(place_parts) > 1 else place_parts[0]
-        city = place_parts[0] if len(place_parts) > 1 else ''
-
-        return {
-            'country': country,
-            'city': city,
-            'latitude': str(value.latitude),
-            'longitude': str(value.longitude),
-            'name': value.name,
-            'formatted_address': value.formatted_address,
-        }
-
+    def to_representation(self, obj):
+        return obj.to_dict() if obj else None
+    
     def to_internal_value(self, data):
-        """
-        Parses the incoming data and converts it into a Places object.
-        """
-        if not isinstance(data, dict):
-            raise serializers.ValidationError("Expected a dictionary input for Places")
-
-        country = data.get('country')
-        if not isinstance(country, str) or not country:
-            raise serializers.ValidationError({"country": "Country must be a non-empty string"})
-
-        city = data.get('city')
-        if not isinstance(city, str) or not city:
-            raise serializers.ValidationError({"city": "City must be a non-empty string"})
-
-        latitude = data.get('latitude')
-        try:
-            latitude = Decimal(latitude)
-        except (ValueError, TypeError, InvalidOperation):
-            raise serializers.ValidationError({"latitude": "Latitude must be a valid number"})
-
-        longitude = data.get('longitude')
-        try:
-            longitude = Decimal(longitude)
-        except (ValueError, TypeError, InvalidOperation):
-            raise serializers.ValidationError({"longitude": "Longitude must be a valid number"})
-        
-        name = data.get('name')
-        formatted_address = data.get('formatted_address')
-
-        place = f"{country}, {city}" 
-
-        return Places(place, latitude, longitude, name, formatted_address)
+        place_from_dict =  Places.from_dict(data)
+        return place_from_dict

--- a/places/serializers.py
+++ b/places/serializers.py
@@ -16,6 +16,9 @@ class PlacesSerializerField(serializers.Field):
         if not value or not isinstance(value, Places):
             return None
 
+        if not value.place:
+            return None
+
         place_parts = value.place.split(', ')
         country = place_parts[1] if len(place_parts) > 1 else place_parts[0]
         city = place_parts[0] if len(place_parts) > 1 else ''

--- a/places/serializers.py
+++ b/places/serializers.py
@@ -10,7 +10,12 @@ class PlacesSerializerField(serializers.Field):
     """
 
     def to_representation(self, obj):
-        return obj.to_dict() if obj else None
+        if isinstance(obj, Places):
+            return obj.to_dict()
+        elif isinstance(obj, dict):
+            return obj
+        else:
+            return None
     
     def to_internal_value(self, data):
         place_from_dict =  Places.from_dict(data)

--- a/places/serializers.py
+++ b/places/serializers.py
@@ -1,0 +1,51 @@
+from rest_framework import serializers
+
+
+class PlacesSerializerField(serializers.Field):
+    """
+    Custom serializer field for handling a Places object represented as a string.
+    The expected format is "country,city,latitude,longitude".
+    """
+
+    def to_representation(self, value):
+        """
+        Converts the Places object to a dictionary for serialization.
+        """
+        if not value:
+            return None
+
+        parts = [part.strip() for part in str(value).split(',')]
+        if len(parts) < 4:
+            raise serializers.ValidationError("Invalid input format for Places")
+
+        return {
+            'country': parts[0],
+            'city': parts[1],
+            'latitude': parts[2],
+            'longitude': parts[3]
+        }
+
+    def to_internal_value(self, data):
+        """
+        Parses the incoming data and converts it into a format suitable for the Places object.
+        """
+        if not isinstance(data, str):
+            raise serializers.ValidationError("Expected a string input for Places")
+
+        parts = [part.strip() for part in data.split(',')]
+        if len(parts) != 4:
+            raise serializers.ValidationError("Expected format: country,city,latitude,longitude")
+
+        try:
+            country, city, latitude, longitude = parts
+            latitude = float(latitude)
+            longitude = float(longitude)
+        except ValueError:
+            raise serializers.ValidationError("Latitude and longitude must be valid numbers")
+
+        return {
+            'country': country,
+            'city': city,
+            'latitude': latitude,
+            'longitude': longitude
+        }

--- a/places/static/places/places.css
+++ b/places/static/places/places.css
@@ -1,4 +1,4 @@
-.places-widget {
+/* .places-widget {
   overflow: hidden;
 }
   .places-widget > input:first-child {
@@ -12,4 +12,4 @@
   .places-widget > div {
     border: 1px solid #CACACA;
     margin-top: 10px;
-  }
+  } */

--- a/places/static/places/places.js
+++ b/places/static/places/places.js
@@ -1,8 +1,14 @@
 function setupDjangoPlaces(mapConfig, markerConfig, childs) {
+  var searchBox = new google.maps.places.SearchBox(childs[0]);
   var latInput = childs[1];
   var lngInput = childs[2];
-  var searchBox = new google.maps.places.SearchBox(childs[0]);
-  var gmap = new google.maps.Map(childs[3], mapConfig);
+  var nameInput = childs[3];
+  var addressInput = childs[4];
+  var countryInput = childs[5];
+  var cityInput = childs[6];  
+  var stateInput = childs[7];
+  var gmap = new google.maps.Map(childs[8], mapConfig);
+
   var marker = new google.maps.Marker(markerConfig);
 
   if (latInput.value && lngInput.value) {
@@ -32,6 +38,30 @@ function setupDjangoPlaces(mapConfig, markerConfig, childs) {
       };
       marker.setPosition(place.geometry.location);
       marker.setMap(gmap);
+      console.log('place', place)
+
+
+      let country 
+      let city
+      let state
+
+      place.address_components.forEach(function(component) {
+        if (component.types.includes("country")) {
+          country = component.long_name;
+        }
+        if (component.types.includes("locality") || component.types.includes("postal_town")) {
+          city = component.long_name;
+        }
+        if (component.types.includes("administrative_area_level_1")) {
+          state = component.long_name;
+        }
+      });
+
+      nameInput.value = place.name;
+      addressInput.value = place.formatted_address;
+      countryInput.value = country;
+      cityInput.value = city;
+      stateInput.value = state;
       latInput.value = place.geometry.location.lat();
       lngInput.value = place.geometry.location.lng();
       gmap.setCenter(place.geometry.location);

--- a/places/widgets.py
+++ b/places/widgets.py
@@ -1,17 +1,16 @@
 # -*- coding: utf-8 -*-
-
 from django.forms import widgets
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 from .conf import settings
+from . import Places
 
 
 class PlacesWidget(widgets.MultiWidget):
     template_name = 'places/widgets/places.html'
 
     def __init__(self, attrs=None):
-        print("Initializing PlacesWidget")
         _widgets = (
             widgets.TextInput(
                 attrs={'data-geo': 'formatted_address', 'data-id': 'map_place'}
@@ -34,24 +33,24 @@ class PlacesWidget(widgets.MultiWidget):
             widgets.TextInput(attrs={'placeholder': 'Formatted Address', 'id': 'id_location_formatted_address'}),
             widgets.TextInput(attrs={'placeholder': 'Country', 'id': 'id_location_country'}),
             widgets.TextInput(attrs={'placeholder': 'City', 'id': 'id_location_city'}),
-            widgets.TextInput(attrs={'placeholder': 'City', 'id': 'id_location_state'}),
+            widgets.TextInput(attrs={'placeholder': 'State', 'id': 'id_location_state'}),
             
         )
         super(PlacesWidget, self).__init__(_widgets, attrs)
 
     def decompress(self, value):
-        print("Decompressing value in PlacesWidget:", value)
         if isinstance(value, str):
             return value.rsplit(',')
         if value:
+            if isinstance(value, Places):
+                value = value.to_dict()
             print('value from decompress', value)
-            place = f'{value.country}, {value.city}, {value.formatted_address}'
-            return [place, value.latitude, value.longitude]
+            place = f'{value["country"]}, {value["city"]}, {value["formatted_address"]}'
+            return [place, value["latitude"], value["longitude"], value["name"], value["formatted_address"], value["country"], value["city"], value["state"]]
         return [None, None]
 
     def get_context(self, name, value, attrs):
         context = super(PlacesWidget, self).get_context(name, value, attrs)
-        print("Context in PlacesWidget for", name, ":", context)
         context['map_widget_height'] = settings.MAP_WIDGET_HEIGHT
         context['map_options'] = settings.MAP_OPTIONS
         context['marker_options'] = settings.MARKER_OPTIONS

--- a/places/widgets.py
+++ b/places/widgets.py
@@ -11,6 +11,7 @@ class PlacesWidget(widgets.MultiWidget):
     template_name = 'places/widgets/places.html'
 
     def __init__(self, attrs=None):
+        print("Initializing PlacesWidget")
         _widgets = (
             widgets.TextInput(
                 attrs={'data-geo': 'formatted_address', 'data-id': 'map_place'}
@@ -29,10 +30,17 @@ class PlacesWidget(widgets.MultiWidget):
                     'placeholder': _('Longitude'),
                 }
             ),
+            widgets.TextInput(attrs={'placeholder': 'Name', 'id': 'id_location_name'}),
+            widgets.TextInput(attrs={'placeholder': 'Formatted Address', 'id': 'id_location_formatted_address'}),
+            widgets.TextInput(attrs={'placeholder': 'Country', 'id': 'id_location_country'}),
+            widgets.TextInput(attrs={'placeholder': 'City', 'id': 'id_location_city'}),
+            widgets.TextInput(attrs={'placeholder': 'City', 'id': 'id_location_state'}),
+            
         )
         super(PlacesWidget, self).__init__(_widgets, attrs)
 
     def decompress(self, value):
+        print("Decompressing value in PlacesWidget:", value)
         if isinstance(value, str):
             return value.rsplit(',')
         if value:
@@ -43,6 +51,7 @@ class PlacesWidget(widgets.MultiWidget):
 
     def get_context(self, name, value, attrs):
         context = super(PlacesWidget, self).get_context(name, value, attrs)
+        print("Context in PlacesWidget for", name, ":", context)
         context['map_widget_height'] = settings.MAP_WIDGET_HEIGHT
         context['map_options'] = settings.MAP_OPTIONS
         context['marker_options'] = settings.MARKER_OPTIONS

--- a/places/widgets.py
+++ b/places/widgets.py
@@ -36,7 +36,9 @@ class PlacesWidget(widgets.MultiWidget):
         if isinstance(value, str):
             return value.rsplit(',')
         if value:
-            return [value.place, value.latitude, value.longitude]
+            print('value from decompress', value)
+            place = f'{value.country}, {value.city}, {value.formatted_address}'
+            return [place, value.latitude, value.longitude]
         return [None, None]
 
     def get_context(self, name, value, attrs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "Django>=3.0",
+    'djangorestframework>=3.0',
 ]
 
 [project.urls]

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+
+from rest_framework import serializers
+
+from places.serializers import PlacesSerializerField
+
+
+
+class PlaceSerializerFieldRepresentation(TestCase):
+
+    def setUp(self):
+        self.field = PlacesSerializerField()
+
+    def test_valid_representation(self):
+        valid_input = "USA,New York,40.7128,-74.0060"
+        expected_output = {
+            'country': 'USA',
+            'city': 'New York',
+            'latitude': '40.7128',
+            'longitude': '-74.0060'
+        }
+        self.assertEqual(self.field.to_representation(valid_input), expected_output)
+
+    def test_invalid_representation(self):
+        invalid_input = "Incomplete data"
+        with self.assertRaises(serializers.ValidationError):
+            self.field.to_representation(invalid_input)
+
+    def test_null_representation(self):
+        null_input = None
+        self.assertIsNone(self.field.to_representation(null_input))
+
+
+
+class TestPlaceSerializerFieldToInternalValue(TestCase):
+    def setUp(self):
+        self.field = PlacesSerializerField()
+
+    def test_valid_input(self):
+        input_data = "USA,New York,40.7128,-74.0060"
+        expected_output = {
+            'country': 'USA',
+            'city': 'New York',
+            'latitude': 40.7128,
+            'longitude': -74.0060
+        }
+        self.assertEqual(self.field.to_internal_value(input_data), expected_output)
+
+    def test_invalid_input(self):
+        invalid_data = "Incomplete data"
+        with self.assertRaises(serializers.ValidationError):
+            self.field.to_internal_value(invalid_data)
+
+    def test_null_input(self):
+        null_input = None
+        with self.assertRaises(serializers.ValidationError):
+            self.field.to_internal_value(null_input)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,53 +1,60 @@
 from django.test import TestCase
-
 from rest_framework import serializers
-
 from places.serializers import PlacesSerializerField
-
-
+from places.fields import Places  
 
 class PlaceSerializerFieldRepresentation(TestCase):
-
     def setUp(self):
         self.field = PlacesSerializerField()
 
     def test_valid_representation(self):
-        valid_input = "USA,New York,40.7128,-74.0060"
+        valid_places = Places("USA, New York", "40.7128", "-74.0060")
         expected_output = {
             'country': 'USA',
             'city': 'New York',
             'latitude': '40.7128',
             'longitude': '-74.0060'
         }
-        self.assertEqual(self.field.to_representation(valid_input), expected_output)
+        self.assertEqual(self.field.to_representation(valid_places), expected_output)
 
     def test_invalid_representation(self):
-        invalid_input = "Incomplete data"
-        with self.assertRaises(serializers.ValidationError):
-            self.field.to_representation(invalid_input)
+        invalid_places = "Incomplete data"  # This should be an invalid type
+        result = self.field.to_representation(invalid_places)
+        self.assertIsNone(result)
 
     def test_null_representation(self):
         null_input = None
         self.assertIsNone(self.field.to_representation(null_input))
-
-
 
 class TestPlaceSerializerFieldToInternalValue(TestCase):
     def setUp(self):
         self.field = PlacesSerializerField()
 
     def test_valid_input(self):
-        input_data = "USA,New York,40.7128,-74.0060"
-        expected_output = {
+        input_data = {
             'country': 'USA',
             'city': 'New York',
-            'latitude': 40.7128,
-            'longitude': -74.0060
+            'latitude': '40.7128',
+            'longitude': '-74.0060'
         }
-        self.assertEqual(self.field.to_internal_value(input_data), expected_output)
+        expected_output = Places("USA, New York", 40.7128, -74.0060)
+        result = self.field.to_internal_value(input_data)
+        self.assertEqual(result.place, expected_output.place)
+        self.assertEqual(result.latitude, expected_output.latitude)
+        self.assertEqual(result.longitude, expected_output.longitude)
 
-    def test_invalid_input(self):
-        invalid_data = "Incomplete data"
+    def test_invalid_input_missing_fields(self):
+        invalid_data = {"country": "USA"}  # Missing other fields
+        with self.assertRaises(serializers.ValidationError):
+            self.field.to_internal_value(invalid_data)
+
+    def test_invalid_input_wrong_types(self):
+        invalid_data = {
+            'country': 'USA',
+            'city': 'New York',
+            'latitude': 'not_a_number',
+            'longitude': '-74.0060'
+        }
         with self.assertRaises(serializers.ValidationError):
             self.field.to_internal_value(invalid_data)
 


### PR DESCRIPTION
This PR is expected to cater those users building a API with Django-rest-framework and want to use the location field in their responses.

This PR introduces the `PlacesSerializerField` to improve the handling of geolocation data in our Django application. The field manages comma-separated geolocation strings, providing structured output and ensuring data integrity.

**Key Changes:**
- Added `PlacesSerializerField` in `serializers.py`, supporting the format "country,city,latitude,longitude".
- Implemented tests for both `to_representation` and `to_internal_value` methods.
- Updated project dependencies to include `djangorestframework`.

**Testing:**
- Comprehensive tests have been added to validate the functionality of `PlacesSerializerField`, covering various input scenarios.

**Dependencies:**
- Added `djangorestframework` to enhance API capabilities.